### PR TITLE
update MenuPane dependencies

### DIFF
--- a/gallery_manifest.json
+++ b/gallery_manifest.json
@@ -117,7 +117,7 @@
                     "version": ""
                 },
                 {
-                    "name": "onyx",
+                    "name": "layout",
                     "version": ""
                 }
             ],


### PR DESCRIPTION
Update the listed dependencies for MenuPane - fixed to support Enyo 2.0b5 and Slideable is now in layout, not onyx.
